### PR TITLE
Make newtypes abstract

### DIFF
--- a/shared/src/main/scala/io/estatico/newtype/BaseNewType.scala
+++ b/shared/src/main/scala/io/estatico/newtype/BaseNewType.scala
@@ -1,5 +1,7 @@
 package io.estatico.newtype
 
+import scala.reflect.ClassTag
+
 /** Base skeleton for building newtypes. */
 trait BaseNewType {
   type Base
@@ -22,11 +24,15 @@ trait BaseNewType {
 
 object BaseNewType {
   /** `Type` implementation for all newtypes; see `BaseNewType`. */
-  type Aux[B, T, R] = B with Meta[T, R]
+  type Aux[B, T, R] <: B with Meta[T, R]
   trait Meta[T, R]
 
   /** Helper trait to refine Repr via a type parameter. */
   trait Of[R] extends BaseNewType {
     final type Repr = R
   }
+
+  // Since Aux is abstract, this is necessary to make Arrays work.
+  @inline implicit def classTag[B, T, R](implicit base: ClassTag[B]): ClassTag[Aux[B, T, R]] =
+    ClassTag(base.runtimeClass)
 }

--- a/shared/src/main/scala/io/estatico/newtype/NewType.scala
+++ b/shared/src/main/scala/io/estatico/newtype/NewType.scala
@@ -14,7 +14,7 @@ object NewType {
 trait NewTypeAutoOps extends BaseNewType {
   implicit def toNewTypeOps(
     x: Type
-  ): NewTypeOps[Type, Tag, Repr] = new NewTypeOps[Type, Tag, Repr](x)
+  ): NewTypeOps[Base, Tag, Repr] = new NewTypeOps[Base, Tag, Repr](x)
 }
 
 trait NewTypeApply extends BaseNewType {

--- a/shared/src/test/scala/io/estatico/newtype/NewTypeTest.scala
+++ b/shared/src/test/scala/io/estatico/newtype/NewTypeTest.scala
@@ -54,6 +54,14 @@ class NewTypeTest extends FlatSpec with PropertyChecks with Matchers {
     (List(Foo(1)).coerce[List[Int]]: List[Int]) shouldEqual List(1)
   }
 
+  it should "work in Arrays" in {
+    type Foo = Foo.Type
+    object Foo extends NewType.Default[Int]
+
+    val foo = Foo(42)
+    Array(foo).head shouldEqual foo
+  }
+
   "NewTypeApply" should "automatically create an apply method" in {
     object PersonId extends NewType.Of[Int] with NewTypeApply
     PersonId(1) shouldEqual 1
@@ -108,6 +116,14 @@ class NewTypeTest extends FlatSpec with PropertyChecks with Matchers {
     (Foo(1).coerce[Int]: Int) shouldEqual 1
     (List(1).coerce[List[Foo]]: List[Foo]) shouldEqual List(1)
     (List(Foo(1)).coerce[List[Int]]: List[Int]) shouldEqual List(1)
+  }
+
+  it should "work in Arrays" in {
+    type Foo = Foo.Type
+    object Foo extends NewSubType.Default[Int]
+
+    val foo = Foo(-273)
+    Array(foo).head shouldEqual foo
   }
 
   "Coercible" should "work across newtypes" in {

--- a/shared/src/test/scala/io/estatico/newtype/macros/NewTypeMacrosTest.scala
+++ b/shared/src/test/scala/io/estatico/newtype/macros/NewTypeMacrosTest.scala
@@ -45,6 +45,11 @@ class NewTypeMacrosTest extends FlatSpec with Matchers {
     res shouldBe 4
   }
 
+  it should "work in arrays" in {
+    val foo = Foo(313)
+    Array(foo).head shouldBe foo
+  }
+
   behavior of "@newtype class"
 
   it should "not expose a default constructor" in {
@@ -97,6 +102,12 @@ class NewTypeMacrosTest extends FlatSpec with Matchers {
 
     someOrZero(x) shouldBe List(1)
     someOrZero(y) shouldBe List(0)
+  }
+
+  it should "work in arrays" in {
+    val repr = Set(Option("newtypes"))
+    val ot = OptionT(repr)
+    Array(ot).head shouldBe ot
   }
 
   behavior of "@newtype with type bounds"


### PR DESCRIPTION
This prevents scalac from dealiasing thus improving type inference.
Especially important when using type lambdas.

Also add ClassTag implicits to ensure Arrays keep working.