### PR TITLE
upgrade to scala 2.12.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.4
+  - 2.12.5
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
there is report that newtype stopped working for 2.12.5 on gitter, so let's see how it runs on travis. 