### PR TITLE
Fixups before v0.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,27 +173,30 @@ object Nel {
 }
 ```
 
-### Generic Instances
+### Automatically Deriving Instances
 
-In some cases, you want to generically provide instances for a certain type class for
-all new types based. You can take advantage of the `Coercible`
+In some cases, you want may want to automatically derive type class instances
+for all newtypes. You can take advantage of the `Coercible`
 type class to achieve that.
 
-Here is an example to provide `Eq` instances for all new type using `Eq` instances of base type. 
+Here is an example of automatically deriving `Eq` instances for all newtypes.
 
 ```scala
-scala> implicit def coercibleEq[A, B](implicit ev: Coercible[Eq[A], Eq[B]], A: Eq[A]): Eq[B] =
-    ev([Eq[B]])
-    
-scala> @newtype case class Foo(x: Int)
+scala> :paste
 
-scala> import cats.implicits._
+import cats._, cats.implicits._
+
+/** If we have an Eq instance for Repr type R, derive an Eq instance for  NewType N. */
+implicit def coercibleEq[R, N](implicit ev: Coercible[Eq[R], Eq[N]], R: Eq[R]): Eq[N] =
+  ev([Eq[R]])
+
+@newtype case class Foo(x: Int)
+
+// Exiting paste mode, now interpreting.
 
 scala> Foo(1) === Foo(2)
 res0: Boolean = false
 ```
-
-
 
 ### Legacy encoding
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ import cats._, cats.implicits._
 
 /** If we have an Eq instance for Repr type R, derive an Eq instance for  NewType N. */
 implicit def coercibleEq[R, N](implicit ev: Coercible[Eq[R], Eq[N]], R: Eq[R]): Eq[N] =
-  ev([Eq[R]])
+  ev(R)
 
 @newtype case class Foo(x: Int)
 

--- a/cats-tests/shared/src/test/scala/io/estatico/newtype/NewTypeCatsTest.scala
+++ b/cats-tests/shared/src/test/scala/io/estatico/newtype/NewTypeCatsTest.scala
@@ -5,8 +5,9 @@ import cats.implicits._
 import io.estatico.newtype.ops._
 import io.estatico.newtype.macros.{newsubtype, newtype}
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class NewTypeCatsTest extends FlatSpec with Matchers {
+class NewTypeCatsTest extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
 
   import NewTypeCatsTest._
 
@@ -120,6 +121,13 @@ class NewTypeCatsTest extends FlatSpec with Matchers {
 
   "Monoid[SubNel[A]]" should "work" in {
     SubNel.of(1, 2, 3).combine(SubNel.of(4, 5, 6)) shouldBe SubNel.of(1, 2, 3, 4, 5, 6)
+  }
+
+  "Coercible" should "support automatic type class derivation" in {
+    implicit def coercibleShow[R, N](implicit ev: Coercible[Show[R], Show[N]], R: Show[R]): Show[N] = ev(R)
+    @newtype case class Foo(private val x: Int)
+    forAll { (n: Int) => Foo(n).show shouldBe n.show }
+    Show[Foo] shouldBe Show[Int]
   }
 }
 

--- a/shared/src/main/scala/io/estatico/newtype/Coercible.scala
+++ b/shared/src/main/scala/io/estatico/newtype/Coercible.scala
@@ -12,6 +12,11 @@ object Coercible {
   def instance[A, B]: Coercible[A, B] = _instance.asInstanceOf[Coercible[A, B]]
 
   private val _instance = new Coercible[Any, Any] {}
+
+  // Support nested type constructors
+  implicit def unsafeWrapMM[M1[_], M2[_], A, B](
+    implicit ev: Coercible[M2[A], M2[B]]
+  ): Coercible[M1[M2[A]], M1[M2[B]]] = Coercible.instance
 }
 
 final class CoercibleIdOps[A](val repr: A) extends AnyVal {

--- a/shared/src/main/scala/io/estatico/newtype/macros/NewTypeMacros.scala
+++ b/shared/src/main/scala/io/estatico/newtype/macros/NewTypeMacros.scala
@@ -254,17 +254,19 @@ private[macros] class NewTypeMacros(val c: blackbox.Context)
     tparamsNoVar: List[TypeDef], tparamNames: List[TypeName], tparamsWild: List[TypeDef]
   ): List[Tree] = {
     if (tparamsNoVar.isEmpty) {
-      List(q"def deriving[T[_]](implicit ev: T[Repr]): T[Type] = ev.asInstanceOf[T[Type]]")
+      List(q"def deriving[TC[_]](implicit ev: TC[Repr]): TC[Type] = ev.asInstanceOf[TC[Type]]")
     } else {
+      // Creating a fresh type name so it doesn't collide with the tparams passed in.
+      val TC = TypeName(c.freshName("TC"))
       List(
         q"""
-          def deriving[T[_], ..$tparamsNoVar](
-            implicit ev: T[Repr[..$tparamNames]]
-          ): T[Type[..$tparamNames]] = ev.asInstanceOf[T[Type[..$tparamNames]]]
+          def deriving[$TC[_], ..$tparamsNoVar](
+            implicit ev: $TC[Repr[..$tparamNames]]
+          ): $TC[Type[..$tparamNames]] = ev.asInstanceOf[$TC[Type[..$tparamNames]]]
         """,
         q"""
-          def derivingK[T[_[..$tparamsWild]]](implicit ev: T[Repr]): T[Type] =
-            ev.asInstanceOf[T[Type]]
+          def derivingK[$TC[_[..$tparamsWild]]](implicit ev: $TC[Repr]): $TC[Type] =
+            ev.asInstanceOf[$TC[Type]]
         """
       )
 

--- a/shared/src/main/scala/io/estatico/newtype/macros/NewTypeMacros.scala
+++ b/shared/src/main/scala/io/estatico/newtype/macros/NewTypeMacros.scala
@@ -174,11 +174,11 @@ private[macros] class NewTypeMacros(val c: blackbox.Context)
   ): List[Tree] = {
     if (!clsDef.mods.hasFlag(Flag.CASE)) Nil else List(
       if (tparamsNoVar.isEmpty) {
-        q"def apply(${valDef.name}: ${valDef.tpt}): Type = ${valDef.name}.asInstanceOf[Type]"
+        q"def apply(${valDef.name}: ${valDef.tpt}): ${clsDef.name} = ${valDef.name}.asInstanceOf[${clsDef.name}]"
       } else {
         q"""
-          def apply[..$tparamsNoVar](${valDef.name}: ${valDef.tpt}): Type[..$tparamNames] =
-            ${valDef.name}.asInstanceOf[Type[..$tparamNames]]
+          def apply[..$tparamsNoVar](${valDef.name}: ${valDef.tpt}): ${clsDef.name}[..$tparamNames] =
+            ${valDef.name}.asInstanceOf[${clsDef.name}[..$tparamNames]]
         """
       }
     )

--- a/shared/src/test/scala/io/estatico/newtype/macros/NewTypeMacrosTest.scala
+++ b/shared/src/test/scala/io/estatico/newtype/macros/NewTypeMacrosTest.scala
@@ -315,6 +315,13 @@ class NewTypeMacrosTest extends FlatSpec with Matchers {
     @newsubtype(optimizeOps = false) case class Bar[A](value: A)
     Bar("foo").value shouldBe "foo"
   }
+
+  behavior of "Coercible"
+
+  it should "work for nested type constructors" in {
+    val x = List(Option(1))
+    val y = x.coerce[List[Option[Foo]]]
+  }
 }
 
 object NewTypeMacrosTest {


### PR DESCRIPTION
* Improve `apply` return type (omit `.Type` suffix).
* Support Coercible for nested type constructors
* Fix for #21 (`deriving` type param name clashing)