### PR TITLE
Add full smart constructor example in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Using `class` will not generate a smart constructor (no `apply` method). This al
 you to specify your own. Note that `new` never works for newtypes and will fail to compile.
 
 ```scala
+  import io.estatico.newtype.ops._
   @newtype class Id(val strValue: String)
 
   object Id {

--- a/README.md
+++ b/README.md
@@ -165,10 +165,16 @@ Using `class` will not generate a smart constructor (no `apply` method). This al
 you to specify your own. Note that `new` never works for newtypes and will fail to compile.
 
 ```scala
-@newtype class N(a: A)
-object N {
-  def apply(a: A): N = ???
-}
+  @newtype class Id(val strValue: String)
+
+  object Id {
+    def apply(str: String): Either[String, Id] = {
+      if (str.isEmpty)
+        Left("Id cannot be empty")
+      else
+        Right(str.coerce)
+    }
+  }
 ```
 
 If you wish to generate an accessor method for your underlying value, you can define it as `val`


### PR DESCRIPTION
Took me a while to figure out that I need to use `coerce` in smart constructor implementation as it was introduced later in the readme 😅 