### PR TITLE
WIP - name-based extractors for unapply to drop allocation of Some

### DIFF
--- a/shared/src/main/scala/io/estatico/newtype/macros/NewTypeMacros.scala
+++ b/shared/src/main/scala/io/estatico/newtype/macros/NewTypeMacros.scala
@@ -188,11 +188,24 @@ private[macros] class NewTypeMacros(val c: blackbox.Context)
       // Note that our unapply method should Some since its isEmpty/get is constant.
       List(
         if (tparamsNoVar.isEmpty) {
-          q"""def unapply(x: ${clsDef.name}): Some[${valDef.tpt}] =
-              Some(x.asInstanceOf[${valDef.tpt}])"""
+          q"""class UnapplyOps(val x: ${clsDef.name}) extends AnyVal {
+                @inline def isEmpty: Boolean = false
+                @inline def get: ${valDef.tpt} = x.asInstanceOf[${valDef.tpt}]
+             }
+           """
         } else {
-          q"""def unapply[..$tparamsNoVar](x: ${clsDef.name}[..$tparamNames]): Some[${valDef.tpt}] =
-              Some(x.asInstanceOf[${valDef.tpt}])"""
+          q"""class UnapplyOps[..$tparamsNoVar](val x: ${clsDef.name}[..$tparamNames]) extends AnyVal {
+                @inline def isEmpty: Boolean = false
+                @inline def get: ${valDef.tpt} = x.asInstanceOf[${valDef.tpt}]
+             }
+           """
+        },
+        if (tparamsNoVar.isEmpty) {
+          q"""def unapply(x: ${clsDef.name}): UnapplyOps =
+              new UnapplyOps(x)"""
+        } else {
+          q"""def unapply[..$tparamsNoVar](x: ${clsDef.name}[..$tparamNames]): UnapplyOps =
+              new UnapplyOps(x)"""
         }
       )
     }


### PR DESCRIPTION
Initial attempt at implementation of #46 - I have checked and this seems to work as it should, but sadly usage of another value class to introduce allocation-less name-based extractor introduces an usage limitation for macro annotations - it's impossible to declare a value class inside of another class and sadly, test suite classes are one of potential use cases like that. Frankly, I have no idea how and if this can be circumvented but maybe some other soul can find a way to solve this riddle.

Tests fail, obviously, as macro annotations now won't compile with `unapply = true` when declared inside of a class.