### PR TITLE
Update build for 2.13.0 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ scala:
   - 2.10.7
   - 2.11.12
   - 2.12.8
-  - 2.13.0-RC2
+  - 2.13.0
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 branches:
   only:

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ lazy val catsTests = crossProject(JSPlatform, JVMPlatform).in(file("cats-tests")
       if (scalaVersion.value.startsWith("2.10."))
         "org.typelevel" %%% "cats-core" % "1.2.0"
       else
-        "org.typelevel" %%% "cats-core" % "2.0.0-M2"
+        "org.typelevel" %%% "cats-core" % "2.0.0-M4"
     }
   )
 
@@ -100,6 +100,7 @@ lazy val defaultSettings = Seq(
         "-Ymacro-annotations"
       )
   }.toList.flatten,
+  macrocompatDependency,
   defaultLibraryDependencies,
   libraryDependencies ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
@@ -136,12 +137,23 @@ lazy val defaultScalacOptions = scalacOptions ++= Seq(
     Seq("-Xlint:-unused,_")
 })
 
+// Only include for 2.10; see https://github.com/milessabin/macro-compat/pull/85 for discussion
+lazy val macrocompatDependency = libraryDependencies ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, v)) if v < 11 =>
+      Seq(
+        "org.typelevel" %% "macro-compat" % "1.1.1"
+      )
+    case _ =>
+      Nil
+  }
+}
+
 lazy val defaultLibraryDependencies = libraryDependencies ++= Seq(
-  "org.typelevel" %% "macro-compat" % "1.1.1",
   scalaOrganization.value % "scala-reflect" % scalaVersion.value % Provided,
   scalaOrganization.value % "scala-compiler" % scalaVersion.value % Provided,
   "org.scalacheck" %%% "scalacheck" % "1.14.0" % Test,
-  "org.scalatest" %%% "scalatest" % "3.0.8-RC4" % Test
+  "org.scalatest" %%% "scalatest" % "3.0.8" % Test
 )
 
 def scalaPartV = Def.setting(CrossVersion.partialVersion(scalaVersion.value))

--- a/shared/src/main/scala/io/estatico/newtype/macros/package.scala
+++ b/shared/src/main/scala/io/estatico/newtype/macros/package.scala
@@ -1,0 +1,4 @@
+package io.estatico.newtype
+
+package object macros extends ScalaVersionSpecifics
+

--- a/shared/src/main/scala_2.10/io/estatico/newtype/macros/ScalaVersionSpecifics.scala
+++ b/shared/src/main/scala_2.10/io/estatico/newtype/macros/ScalaVersionSpecifics.scala
@@ -1,0 +1,3 @@
+package io.estatico.newtype.macros
+
+trait ScalaVersionSpecifics

--- a/shared/src/main/scala_2.11+/io/estatico/newtype/macros/ScalaVersionSpecifics.scala
+++ b/shared/src/main/scala_2.11+/io/estatico/newtype/macros/ScalaVersionSpecifics.scala
@@ -1,0 +1,8 @@
+package io.estatico.newtype.macros
+
+trait ScalaVersionSpecifics {
+  object macrocompat {
+    class bundle extends annotation.Annotation
+  }
+}
+


### PR DESCRIPTION
  - Work around unavailability of macro-compat for 2.13.
  - Use openjdk8 in Travis CI since oraclejdk8 is no longer available by
    default

The `ScalaVersionSpecifics` trick was stolen from shapeless.