### PR TITLE
WIP: Add deriving and derivingK to @newtype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val catsTests = crossProject(JSPlatform, JVMPlatform).in(file("cats-tests")
   .settings(
     name := "newtype-cats-tests",
     description := "Test suite for newtype + cats interop",
-    libraryDependencies += "org.typelevel" %%% "cats-core" % "2.0.0-M4"
+    libraryDependencies += "org.typelevel" %%% "cats-core" % "2.0.0"
   )
 
 lazy val catsTestsJVM = catsTests.jvm

--- a/shared/src/main/scala/io/estatico/newtype/macros/deriving.scala
+++ b/shared/src/main/scala/io/estatico/newtype/macros/deriving.scala
@@ -1,0 +1,57 @@
+package io.estatico.newtype.macros
+
+import scala.annotation.compileTimeOnly
+
+sealed trait deriving
+
+/**
+ * Syntax support for defining newtypes with derived type class instances generated in their companion object.
+ * Heavily inspired by https://github.com/oleg-py/enumeratum-macro
+ */
+object deriving extends deriving {
+  def evicted: Nothing =
+    sys.error("Runtime application of @newtype DSL is not possible")
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_]](implicit sig: T1): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_], M2[_]](implicit sig: T2): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_], M2[_], M3[_]](implicit sig: T3): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_], M2[_], M3[_], M4[_]](implicit sig: T4): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_], M2[_], M3[_], M4[_], M5[_]](implicit sig: T5): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_], M2[_], M3[_], M4[_], M5[_], M6[_]](implicit sig: T6): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_], M2[_], M3[_], M4[_], M5[_], M6[_], M7[_]](implicit sig: T7): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_], M2[_], M3[_], M4[_], M5[_], M6[_], M7[_], M8[_]](implicit sig: T8): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_], M2[_], M3[_], M4[_], M5[_], M6[_], M7[_], M8[_], M9[_]](implicit sig: T9): deriving = evicted
+
+  // Dummies used to give deriving[...] different erased signatures
+  // Which is required for scalac to compile above definitions
+  trait T1; trait T2; trait T3; trait T4; trait T5
+  trait T6; trait T7; trait T8; trait T9
+
+  // Defining them here will make IDEs like IntelliJ not complain about missing implicit values
+  implicit val t1: T1 = null
+  implicit val t2: T2 = null
+  implicit val t3: T3 = null
+  implicit val t4: T4 = null
+  implicit val t5: T5 = null
+  implicit val t6: T6 = null
+  implicit val t7: T7 = null
+  implicit val t8: T8 = null
+  implicit val t9: T9 = null
+}

--- a/shared/src/main/scala/io/estatico/newtype/macros/derivingK.scala
+++ b/shared/src/main/scala/io/estatico/newtype/macros/derivingK.scala
@@ -1,0 +1,58 @@
+package io.estatico.newtype.macros
+
+import scala.annotation.compileTimeOnly
+
+sealed trait derivingK
+
+/**
+ * Higher-kinded version of [[deriving]].
+ */
+object derivingK extends derivingK {
+  def evicted: Nothing =
+    sys.error("Runtime application of @newtype DSL is not possible")
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_[_]]](implicit sig: T1): derivingK = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_[_]], M2[_[_]]](implicit sig: T2): derivingK = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_[_]], M2[_[_]], M3[_[_]]](implicit sig: T3): derivingK = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_[_]], M2[_[_]], M3[_[_]], M4[_[_]]](implicit sig: deriving.T4): derivingK = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_[_]], M2[_[_]], M3[_[_]], M4[_[_]], M5[_[_]]](implicit sig: T5): derivingK = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_[_]], M2[_[_]], M3[_[_]], M4[_[_]], M5[_[_]], M6[_[_]]](implicit sig: T6): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_[_]], M2[_[_]], M3[_[_]], M4[_[_]], M5[_[_]], M6[_[_]], M7[_[_]]](implicit sig: T7): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_[_]], M2[_[_]], M3[_[_]], M4[_[_]], M5[_[_]], M6[_[_]], M7[_[_]], M8[_[_]]](implicit sig: T8): deriving = evicted
+
+  @compileTimeOnly("Part of @newtype DSL that should not be used directly")
+  def apply[M1[_[_]], M2[_[_]], M3[_[_]], M4[_[_]], M5[_[_]], M6[_[_]], M7[_[_]], M8[_[_]], M9[_[_]]](implicit sig: T9): deriving = evicted
+
+  // Dummies used to give derivingK[...] different erased signatures
+  // Which is required for scalac to compile above definitions
+  trait T1; trait T2; trait T3; trait T4; trait T5
+  trait T6; trait T7; trait T8; trait T9
+
+  // Defining them here will make IDEs like IntelliJ not complain about missing implicit values
+  implicit val t1: T1 = null
+  implicit val t2: T2 = null
+  implicit val t3: T3 = null
+  implicit val t4: T4 = null
+  implicit val t5: T5 = null
+  implicit val t6: T6 = null
+  implicit val t7: T7 = null
+  implicit val t8: T8 = null
+  implicit val t9: T9 = null
+}
+
+

--- a/shared/src/main/scala/io/estatico/newtype/macros/newtype.scala
+++ b/shared/src/main/scala/io/estatico/newtype/macros/newtype.scala
@@ -3,6 +3,8 @@ package io.estatico.newtype.macros
 import scala.annotation.StaticAnnotation
 
 class newtype(
+  deriving: deriving = deriving,
+  derivingK: derivingK = derivingK,
   optimizeOps: Boolean = true,
   unapply: Boolean = false,
   debug: Boolean = false,


### PR DESCRIPTION
Allows to have boilerplate for deriving type classes from a reprentation type instance generated by the macro itself so that in many cases users can avoid writing a companion object manually.

Changes:
* add `deriving` and `derivingK` parameters to `@newtype` annotation
* generate implicit companion object members for each mentioned type class
* remove two unused lines in `NetTypeMacros.generateNewType`
* Update cats to stable version

The whole approach is inspired by https://github.com/oleg-py/enumeratum-macro. I made it a WIP as I first wanted to get feedback whether this is seen as a useful addition and whether syntax/naming is fine. If so, I'll write some docs as well.

Example:
```scala
@newtype case class PhoneNumber(value: String)

object PhoneNumber {
  implicit val eq: Eq[PhoneNumber] = deriving
  implicit val show: Show[PhoneNumber] = deriving
  implicit val hash: Hash[PhoneNumber] = deriving
}
```
becomes
```scala
@newtype(deriving[Eq, Show, Hash]) case class PhoneNumber(value: String)
```
More examples can be found in the tests.