### PR TITLE
Stop @newtype to warn for implicit conversions

### DIFF
--- a/shared/src/main/scala/io/estatico/newtype/macros/NewTypeMacros.scala
+++ b/shared/src/main/scala/io/estatico/newtype/macros/NewTypeMacros.scala
@@ -122,10 +122,11 @@ private[macros] class NewTypeMacros(val c: blackbox.Context) {
 
     val baseTypeDef = mkBaseTypeDef(clsDef, reprType, subtype)
     val typeTypeDef = mkTypeTypeDef(clsDef, tparamNames, subtype)
+    val enableImplicits = List( q"import _root_.scala.language.implicitConversions" )
 
     val newtypeObjParents = objParents
     val newtypeObjDef = ModuleDef(
-      objMods, objName, Template(newtypeObjParents, objSelf, objDefs ++ companionExtraDefs ++ Seq(
+      objMods, objName, Template(newtypeObjParents, objSelf, objDefs ++ enableImplicits ++ companionExtraDefs ++ Seq(
         q"type Repr[..$tparams] = $reprType",
         baseTypeDef,
         q"trait Tag[..$tparams] extends _root_.scala.Any",


### PR DESCRIPTION
If you neither set the '-language:implicitConversions' flag, nor the 'import scala.language.implicitConversions', the '@newtype' construct warns for implicit conversions.

I've tried, and this PR prevents it.